### PR TITLE
Localisation add ons

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -48,6 +48,8 @@
 	"CYPHERSYSTEM.SettingMacroAllInOneHint": "With this setting, the item macros created by dragging an item to the macro bar use the All-in-One Roll macro instead of the Quick Roll macro.",
 	"CYPHERSYSTEM.SettingShowWelcome": "Show Welcome Message",
 	"CYPHERSYSTEM.SettingShowWelcomeHint": "Show the welcome message at every launch of this world.",
+	"CYPHERSYSTEM.UnitDistanceMeter": "meter",
+	"CYPHERSYSTEM.UnitDistanceFeet": "feet",
 
 	"CYPHERSYSTEM.WelcomeMessage": "Welcome to the Cypher System!",
 	"CYPHERSYSTEM.GettingStarted": "Getting Started",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1,4 +1,3 @@
-
 {
 	"ACTOR.TypePC": "PC",
 	"ACTOR.TypeNPC": "NPC",
@@ -23,6 +22,25 @@
 	"ITEM.TypeTeen Attack": "Attack (Teen)",
 	"ITEM.TypeTeen Lasting Damage": "Lasting Damage (Teen)",
 	"ITEM.TypeTeen Skill": "Skill (Teen)",
+	
+	"ITEM.NewAbility": "[New Ability]",
+	"ITEM.NewAmmo": "[New Ammo]",
+	"ITEM.NewArmor": "[New Armor]",
+	"ITEM.NewArtifact": "[New Artifact]",
+	"ITEM.NewAttack": "[New Attack]",
+	"ITEM.NewCypher": "[New Cypher]",
+	"ITEM.NewEquipment": "[New Equipment]",
+	"ITEM.NewLastingDamage": "[New Lasting Damage]",
+	"ITEM.NewMaterial": "[New Material]",
+	"ITEM.NewOddity": "[New Oddity]",
+	"ITEM.NewPowerShift": "[New Power Shift]",
+	"ITEM.NewSkill": "[New Skill]",
+	"ITEM.NewTeenAbility": "[New Ability (Teen)]",
+	"ITEM.NewTeenArmor": "[New Armor (Teen)]",
+	"ITEM.NewTeenAttack": "[New Attack (Teen)]",
+	"ITEM.NewTeenLastingDamage": "[New Lasting Damage (Teen)]",
+	"ITEM.NewTeenSkill": "[New Skill (Teen)]",
+	"ITEM.NewDefault": "[New Item]",
 
 	"CYPHERSYSTEM.SettingRollMacro": "Roll Macros Use Effective Difficulty",
 	"CYPHERSYSTEM.SettingRollMacroHint": "With this setting, the steps eased or hindered for roll macros are added and subtracted from the difficulty, respectively. In effect, this gives the effective difficulty that gets beaten by the roll. For example, if you roll a 9 on a roll that is eased by one step, the macro tells you that you beat difficulty 4 (3+1). If you were hindered, it would have told you that you beat difficulty 2 (3-1) instead. With this option deactivated, it will tell you that you have beaten difficulty 3.",

--- a/module/NPC-sheet.js
+++ b/module/NPC-sheet.js
@@ -478,7 +478,28 @@ _onItemCreate(event) {
   // Grab any data associated with this control.
   const data = duplicate(header.dataset);
   // Initialize a default name.
-  const name = `[New ${type.capitalize()}]`;
+  const types = {
+		"ability": game.i18n.localize("ITEM.NewAbility"),
+		"ammo": game.i18n.localize("ITEM.NewAmmo"),
+		"armor": game.i18n.localize("ITEM.NewArmor"),
+		"artifact": game.i18n.localize("ITEM.NewArtifact"),
+		"attack": game.i18n.localize("ITEM.NewAttack"),
+		"cypher": game.i18n.localize("ITEM.NewCypher"),
+		"equipment": game.i18n.localize("ITEM.NewEquipment"),
+		"lasting Damage": game.i18n.localize("ITEM.NewLastingDamage"),
+		"material": game.i18n.localize("ITEM.NewMaterial"),
+		"oddity": game.i18n.localize("ITEM.NewOddity"),
+		"power Shift": game.i18n.localize("ITEM.NewPowerShift"),
+		"skill": game.i18n.localize("ITEM.NewSkill"),
+		"teen Ability": game.i18n.localize("ITEM.NewTeenAbility"),
+		"teen Armor": game.i18n.localize("ITEM.NewTeenArmor"),
+		"teen Attack": game.i18n.localize("ITEM.NewTeenAttack"),
+		"teen lasting Damage": game.i18n.localize("ITEM.NewTeenLastingDamage"),
+		"teen Skill": game.i18n.localize("ITEM.NewTeenSkill"),
+		"default": game.i18n.localize("ITEM.NewDefault")
+	};
+	
+    const name = (types[type] || types["default"]);
   // Prepare the item object.
   const itemData = {
     name: name,

--- a/module/actor-sheet.js
+++ b/module/actor-sheet.js
@@ -833,7 +833,27 @@ export class CypherActorSheet extends ActorSheet {
     // Grab any data associated with this control.
     const data = duplicate(header.dataset);
     // Initialize a default name.
-    const name = `[New ${type.capitalize()}]`;
+	const types = {
+        "ability": game.i18n.localize("ITEM.NewAbility"),
+        "ammo": game.i18n.localize("ITEM.NewAmmo"),
+        "armor": game.i18n.localize("ITEM.NewArmor"),
+        "artifact": game.i18n.localize("ITEM.NewArtifact"),
+        "attack": game.i18n.localize("ITEM.NewAttack"),
+        "cypher": game.i18n.localize("ITEM.NewCypher"),
+        "equipment": game.i18n.localize("ITEM.NewEquipment"),
+        "lasting Damage": game.i18n.localize("ITEM.NewLastingDamage"),
+        "material": game.i18n.localize("ITEM.NewMaterial"),
+        "oddity": game.i18n.localize("ITEM.NewOddity"),
+        "power Shift": game.i18n.localize("ITEM.NewPowerShift"),
+        "skill": game.i18n.localize("ITEM.NewSkill"),
+        "teen Ability": game.i18n.localize("ITEM.NewTeenAbility"),
+        "teen Armor": game.i18n.localize("ITEM.NewTeenArmor"),
+        "teen Attack": game.i18n.localize("ITEM.NewTeenAttack"),
+        "teen lasting Damage": game.i18n.localize("ITEM.NewTeenLastingDamage"),
+        "teen Skill": game.i18n.localize("ITEM.NewTeenSkill"),
+        "default": game.i18n.localize("ITEM.NewDefault")
+    };
+    const name = (types[type] || types["default"]);
     // Prepare the item object.
     const itemData = {
       name: name,

--- a/module/community-sheet.js
+++ b/module/community-sheet.js
@@ -498,7 +498,28 @@ export class CypherCommunitySheet extends ActorSheet {
     // Grab any data associated with this control.
     const data = duplicate(header.dataset);
     // Initialize a default name.
-    const name = `[New ${type.capitalize()}]`;
+    const types = {
+		"ability": game.i18n.localize("ITEM.NewAbility"),
+		"ammo": game.i18n.localize("ITEM.NewAmmo"),
+		"armor": game.i18n.localize("ITEM.NewArmor"),
+		"artifact": game.i18n.localize("ITEM.NewArtifact"),
+		"attack": game.i18n.localize("ITEM.NewAttack"),
+		"cypher": game.i18n.localize("ITEM.NewCypher"),
+		"equipment": game.i18n.localize("ITEM.NewEquipment"),
+		"lasting Damage": game.i18n.localize("ITEM.NewLastingDamage"),
+		"material": game.i18n.localize("ITEM.NewMaterial"),
+		"oddity": game.i18n.localize("ITEM.NewOddity"),
+		"power Shift": game.i18n.localize("ITEM.NewPowerShift"),
+		"skill": game.i18n.localize("ITEM.NewSkill"),
+		"teen Ability": game.i18n.localize("ITEM.NewTeenAbility"),
+		"teen Armor": game.i18n.localize("ITEM.NewTeenArmor"),
+		"teen Attack": game.i18n.localize("ITEM.NewTeenAttack"),
+		"teen lasting Damage": game.i18n.localize("ITEM.NewTeenLastingDamage"),
+		"teen Skill": game.i18n.localize("ITEM.NewTeenSkill"),
+		"default": game.i18n.localize("ITEM.NewDefault")
+	};
+	
+    const name = (types[type] || types["default"]);
     // Prepare the item object.
     const itemData = {
       name: name,

--- a/module/companion-sheet.js
+++ b/module/companion-sheet.js
@@ -523,7 +523,28 @@ _onItemCreate(event) {
   // Grab any data associated with this control.
   const data = duplicate(header.dataset);
   // Initialize a default name.
-  const name = `[New ${type.capitalize()}]`;
+  const types = {
+		"ability": game.i18n.localize("ITEM.NewAbility"),
+		"ammo": game.i18n.localize("ITEM.NewAmmo"),
+		"armor": game.i18n.localize("ITEM.NewArmor"),
+		"artifact": game.i18n.localize("ITEM.NewArtifact"),
+		"attack": game.i18n.localize("ITEM.NewAttack"),
+		"cypher": game.i18n.localize("ITEM.NewCypher"),
+		"equipment": game.i18n.localize("ITEM.NewEquipment"),
+		"lasting Damage": game.i18n.localize("ITEM.NewLastingDamage"),
+		"material": game.i18n.localize("ITEM.NewMaterial"),
+		"oddity": game.i18n.localize("ITEM.NewOddity"),
+		"power Shift": game.i18n.localize("ITEM.NewPowerShift"),
+		"skill": game.i18n.localize("ITEM.NewSkill"),
+		"teen Ability": game.i18n.localize("ITEM.NewTeenAbility"),
+		"teen Armor": game.i18n.localize("ITEM.NewTeenArmor"),
+		"teen Attack": game.i18n.localize("ITEM.NewTeenAttack"),
+		"teen lasting Damage": game.i18n.localize("ITEM.NewTeenLastingDamage"),
+		"teen Skill": game.i18n.localize("ITEM.NewTeenSkill"),
+		"default": game.i18n.localize("ITEM.NewDefault")
+	};
+	
+    const name = (types[type] || types["default"]);
   // Prepare the item object.
   const itemData = {
     name: name,

--- a/module/cyphersystem.js
+++ b/module/cyphersystem.js
@@ -270,12 +270,12 @@ Hooks.once("dragRuler.ready", (SpeedProvider) => {
       let short = 0;
       let long = 0;
       let veryLong = 0;
-      if (token.scene.data.gridUnits == "m" || token.scene.data.gridUnits == "meter" || token.scene.data.gridUnits == "metre" || token.scene.data.gridUnits == "mètre") {
+      if (token.scene.data.gridUnits == "m" || token.scene.data.gridUnits == "meter" || token.scene.data.gridUnits == "metre" || token.scene.data.gridUnits == "mètre" || token.scene.data.gridUnits == game.i18n.localize("CYPHERSYSTEM.UnitDistanceMeter")) {
         immediate = 3;
         short = 15;
         long = 30;
         veryLong = 150;
-      } else if (token.scene.data.gridUnits == "ft" || token.scene.data.gridUnits == "ft." || token.scene.data.gridUnits == "feet") {
+      } else if (token.scene.data.gridUnits == "ft" || token.scene.data.gridUnits == "ft." || token.scene.data.gridUnits == "feet" || token.scene.data.gridUnits == game.i18n.localize("CYPHERSYSTEM.UnitDistanceFeet")) {
         immediate = 10;
         short = 50;
         long = 100;

--- a/module/token-sheet.js
+++ b/module/token-sheet.js
@@ -474,7 +474,28 @@ export class CypherTokenSheet extends ActorSheet {
     // Grab any data associated with this control.
     const data = duplicate(header.dataset);
     // Initialize a default name.
-    const name = `[New ${type.capitalize()}]`;
+    const types = {
+		"ability": game.i18n.localize("ITEM.NewAbility"),
+		"ammo": game.i18n.localize("ITEM.NewAmmo"),
+		"armor": game.i18n.localize("ITEM.NewArmor"),
+		"artifact": game.i18n.localize("ITEM.NewArtifact"),
+		"attack": game.i18n.localize("ITEM.NewAttack"),
+		"cypher": game.i18n.localize("ITEM.NewCypher"),
+		"equipment": game.i18n.localize("ITEM.NewEquipment"),
+		"lasting Damage": game.i18n.localize("ITEM.NewLastingDamage"),
+		"material": game.i18n.localize("ITEM.NewMaterial"),
+		"oddity": game.i18n.localize("ITEM.NewOddity"),
+		"power Shift": game.i18n.localize("ITEM.NewPowerShift"),
+		"skill": game.i18n.localize("ITEM.NewSkill"),
+		"teen Ability": game.i18n.localize("ITEM.NewTeenAbility"),
+		"teen Armor": game.i18n.localize("ITEM.NewTeenArmor"),
+		"teen Attack": game.i18n.localize("ITEM.NewTeenAttack"),
+		"teen lasting Damage": game.i18n.localize("ITEM.NewTeenLastingDamage"),
+		"teen Skill": game.i18n.localize("ITEM.NewTeenSkill"),
+		"default": game.i18n.localize("ITEM.NewDefault")
+	};
+	
+    const name = (types[type] || types["default"]);
     // Prepare the item object.
     const itemData = {
       name: name,

--- a/module/vehicle-sheet.js
+++ b/module/vehicle-sheet.js
@@ -450,7 +450,28 @@ export class CypherVehicleSheet extends ActorSheet {
     // Grab any data associated with this control.
     const data = duplicate(header.dataset);
     // Initialize a default name.
-    const name = `[New ${type.capitalize()}]`;
+    const types = {
+		"ability": game.i18n.localize("ITEM.NewAbility"),
+		"ammo": game.i18n.localize("ITEM.NewAmmo"),
+		"armor": game.i18n.localize("ITEM.NewArmor"),
+		"artifact": game.i18n.localize("ITEM.NewArtifact"),
+		"attack": game.i18n.localize("ITEM.NewAttack"),
+		"cypher": game.i18n.localize("ITEM.NewCypher"),
+		"equipment": game.i18n.localize("ITEM.NewEquipment"),
+		"lasting Damage": game.i18n.localize("ITEM.NewLastingDamage"),
+		"material": game.i18n.localize("ITEM.NewMaterial"),
+		"oddity": game.i18n.localize("ITEM.NewOddity"),
+		"power Shift": game.i18n.localize("ITEM.NewPowerShift"),
+		"skill": game.i18n.localize("ITEM.NewSkill"),
+		"teen Ability": game.i18n.localize("ITEM.NewTeenAbility"),
+		"teen Armor": game.i18n.localize("ITEM.NewTeenArmor"),
+		"teen Attack": game.i18n.localize("ITEM.NewTeenAttack"),
+		"teen lasting Damage": game.i18n.localize("ITEM.NewTeenLastingDamage"),
+		"teen Skill": game.i18n.localize("ITEM.NewTeenSkill"),
+		"default": game.i18n.localize("ITEM.NewDefault")
+	};
+	
+    const name = (types[type] || types["default"]);
     // Prepare the item object.
     const itemData = {
       name: name,

--- a/templates/actor-sheet.html
+++ b/templates/actor-sheet.html
@@ -349,7 +349,7 @@
             {{#if (eq data.settings.gameMode.currentSheet "Teen")}}
             {{#each actor.teenLastingDamage as |item id|}}
             <li class="item flexrow" data-item-id="{{item._id}}" style="color: {{#if data.archived}}grey{{/if}}">
-              <h4 class="item-name"><a class="item-control item-description" title="{{localize 'CYPHERSYSTEM.ShowDescription'}}"><i class="fas fa-angle-{{#if data.showDescription}}down{{else}}right{{/if}} item-angle" aria-hidden="true"></i>{{item.name}} ({{data.lastingDamagePool}}{{#if (eq data.damageType "Permanent")}}, {{localize 'CYPHERSYSTEM.Permanent'}}{{/if}})</a></h4>
+              <h4 class="item-name"><a class="item-control item-description" title="{{localize 'CYPHERSYSTEM.ShowDescription'}}"><i class="fas fa-angle-{{#if data.showDescription}}down{{else}}right{{/if}} item-angle" aria-hidden="true"></i>{{item.name}} ({{#if (eq data.lastingDamagePool "Might")}}{{localize 'CYPHERSYSTEM.Might'}}{{else if (eq data.lastingDamagePool "Speed")}}{{localize 'CYPHERSYSTEM.Speed'}}{{else if (eq data.lastingDamagePool "Intellect")}}{{localize 'CYPHERSYSTEM.Intellect'}}{{else}}{{data.lastingDamagePool}}{{/if}}{{#if (eq data.damageType "Permanent")}}, {{localize 'CYPHERSYSTEM.Permanent'}}{{/if}})</a></h4>
               <div class="item-quantity"><a class="item-control minus-one-damage" title="{{localize 'CYPHERSYSTEM.SubtractQuantity'}}"><i class="fas fa-angle-down"></i></a><p class="number">&nbsp;{{data.lastingDamageAmount}}&nbsp;</p><a class="item-control plus-one-damage" title="{{localize 'CYPHERSYSTEM.AddQuantity'}}"><i class="fas fa-angle-up"></i></a></div>
               <div class="item-controls">
                 <a class="item-control item-edit" title="{{localize 'CYPHERSYSTEM.EditItem'}}"><i class="fas fa-edit"></i></a>
@@ -365,7 +365,7 @@
             {{else}}
             {{#each actor.lastingDamage as |item id|}}
             <li class="item flexrow" data-item-id="{{item._id}}" style="color: {{#if data.archived}}grey{{/if}}">
-              <h4 class="item-name"><a class="item-control item-description" title="{{localize 'CYPHERSYSTEM.ShowDescription'}}"><i class="fas fa-angle-{{#if data.showDescription}}down{{else}}right{{/if}} item-angle" aria-hidden="true"></i>{{item.name}} ({{data.lastingDamagePool}}{{#if (eq data.damageType "Permanent")}}, {{localize 'CYPHERSYSTEM.Permanent'}}{{/if}})</a></h4>
+              <h4 class="item-name"><a class="item-control item-description" title="{{localize 'CYPHERSYSTEM.ShowDescription'}}"><i class="fas fa-angle-{{#if data.showDescription}}down{{else}}right{{/if}} item-angle" aria-hidden="true"></i>{{item.name}} ({{#if (eq data.lastingDamagePool "Might")}}{{localize 'CYPHERSYSTEM.Might'}}{{else if (eq data.lastingDamagePool "Speed")}}{{localize 'CYPHERSYSTEM.Speed'}}{{else if (eq data.lastingDamagePool "Intellect")}}{{localize 'CYPHERSYSTEM.Intellect'}}{{else}}{{data.lastingDamagePool}}{{/if}}{{#if (eq data.damageType "Permanent")}}, {{localize 'CYPHERSYSTEM.Permanent'}}{{/if}})</a></h4>
               <div class="item-quantity"><a class="item-control minus-one-damage" title="{{localize 'CYPHERSYSTEM.SubtractQuantity'}}"><i class="fas fa-angle-down"></i></a><p class="number">&nbsp;{{data.lastingDamageAmount}}&nbsp;</p><a class="item-control plus-one-damage" title="{{localize 'CYPHERSYSTEM.AddQuantity'}}"><i class="fas fa-angle-up"></i></a></div>
               <div class="item-controls">
                 <a class="item-control item-edit" title="{{localize 'CYPHERSYSTEM.EditItem'}}"><i class="fas fa-edit"></i></a>

--- a/templates/item-material-sheet.html
+++ b/templates/item-material-sheet.html
@@ -10,7 +10,7 @@
                     </div>
                     <div class="resources grid grid-3col">
                         <div class="resource flex-center">
-                            <label class="resource-label-normal">{{localize 'ITEM.Units'}}</label>
+                            <label class="resource-label-normal">{{localize 'CYPHERSYSTEM.Units'}}</label>
                             <div class="resource-content flexrow flex-center flex-between">
                                 <input type="text" name="data.quantity" value="{{data.quantity}}" data-dtype="Number"/>
                             </div>

--- a/templates/item-teen lasting damage-sheet.html
+++ b/templates/item-teen lasting damage-sheet.html
@@ -31,7 +31,7 @@
                             <div class="resource-content flexrow flex-center flex-between">
                                 <select name="data.damageType">
                                     {{#select data.damageType}}
-                                    <option value="Lasting">{{localize '"CYPHERSYSTEM.LastingDamage"'}}</option>
+                                    <option value="Lasting">{{localize 'CYPHERSYSTEM.LastingDamage'}}</option>
                                     <option value="Permanent">{{localize 'CYPHERSYSTEM.Permanent'}}</option>
                                     {{/select}}
                                 </select>


### PR DESCRIPTION
- Add localisation for #85 will keeping the current "feet" and "meter" unit in the system
- Added the localisation for new items/elements
- Fix for lasting pool damage localisation not showing on the character sheet (was always in English)
- Fix for the Material Unit localisation in the Material sheet (it was written `{{localize 'ITEM.Units'}}`, which is not an existing string in the JSON, changed to `{{localize 'CYPHERSYSTEM.Units'}}`)
- Fix for the Lasting Damage localisation in the Teen Actor sheet, `"` were surrounding the string: `{{localize '"CYPHERSYSTEM.LastingDamage"'}}`