### PR TITLE
Item list template tweaks

### DIFF
--- a/templates/item-lists/armor-list-teen.html
+++ b/templates/item-lists/armor-list-teen.html
@@ -18,8 +18,6 @@
         {{localize 'CYPHERSYSTEM.HeavyArmor' ~}}
       {{else if (eq item.system.basic.type "artifact") ~}}
         {{localize 'CYPHERSYSTEM.Artifact' ~}}
-      {{else if (eq item.system.basic.type "special ability") ~}}
-        {{localize 'CYPHERSYSTEM.SepcialAbility' ~}}
       {{else if (eq item.system.basic.type "n/a") ~}}
         {{localize 'CYPHERSYSTEM.n/a' ~}}
       {{/if ~}}

--- a/templates/item-lists/armor-list.html
+++ b/templates/item-lists/armor-list.html
@@ -18,8 +18,6 @@
         {{localize 'CYPHERSYSTEM.HeavyArmor' ~}}
       {{else if (eq item.system.basic.type "artifact") ~}}
         {{localize 'CYPHERSYSTEM.Artifact' ~}}
-      {{else if (eq item.system.basic.type "special ability") ~}}
-        {{localize 'CYPHERSYSTEM.SepcialAbility' ~}}
       {{else if (eq item.system.basic.type "n/a") ~}}
         {{localize 'CYPHERSYSTEM.n/a' ~}}
       {{/if ~}}

--- a/templates/item-lists/attacks-list-teen.html
+++ b/templates/item-lists/attacks-list-teen.html
@@ -30,7 +30,7 @@
       {{#unless (eq item.system.basic.notes "") ~}}
         {{localize 'CYPHERSYSTEM.Comma'}}
         {{item.system.basic.notes}}
-      {{/unless ~}}
+      {{~/unless ~}}
       {{localize 'CYPHERSYSTEM.CloseParenthesis'}}
     </h4>
     <div class="item-quantity">{{item.system.basic.damage}}</div>

--- a/templates/item-lists/attacks-list.html
+++ b/templates/item-lists/attacks-list.html
@@ -30,7 +30,7 @@
       {{#unless (eq item.system.basic.notes "") ~}}
         {{localize 'CYPHERSYSTEM.Comma'}}
         {{item.system.basic.notes}}
-      {{/unless ~}}
+      {{~/unless ~}}
       {{localize 'CYPHERSYSTEM.CloseParenthesis'}}
     </h4>
     <div class="item-quantity">{{item.system.basic.damage}}</div>


### PR DESCRIPTION
**Proposed changes**
This PR fixes 2 small issues with item lists templates for the actor sheet.

- 82c4d491b8fcca355e70cfcce5d5bc83bb5967d1 fixes an erroneous space after Notes field in attacks-list templates:
![image](https://user-images.githubusercontent.com/1549691/219941385-fde39545-dc69-457a-9e79-416b83ef26fb.png)
- 4d5ca09da014295c44a832c3e065a9b6d090c718 cleans up the armor-list templates, which have a duplicated block for `else if (eq item.system.basic.type "special ability")`, with the second block never outputting anything because the localization key is misspelled as `CYPHERSYSTEM.SepcialAbility`

**Related issues**
None

**Open questions**
N/A
