### PR TITLE
Remove hudButtons.tokens.tools.push calls

### DIFF
--- a/module/cyphersystem.js
+++ b/module/cyphersystem.js
@@ -335,11 +335,9 @@ Hooks.once("ready", async function () {
 });
 
 Hooks.on("getSceneControlButtons", function (hudButtons) {
-  let tokenControls = hudButtons.find(val => {
-    return val.name == "token";
-  });
+  let tokenControls = hudButtons.tokens;
   if (tokenControls) {
-    tokenControls.tools.push({
+    tokenControls.tools["rollDifficulty"] = {
       name: "rollDifficulty",
       title: game.i18n.localize("CYPHERSYSTEM.DifficultyControlPanel"),
       icon: "fa-solid fa-crosshairs-simple",
@@ -347,10 +345,10 @@ Hooks.on("getSceneControlButtons", function (hudButtons) {
         renderRollDifficultyForm(true);
       },
       button: true
-    });
+    };
   }
   if (tokenControls && game.user.isGM) {
-    tokenControls.tools.push({
+    tokenControls.tools["calculateDifficulty"] = {
       name: "calculateDifficulty",
       title: game.i18n.localize("CYPHERSYSTEM.CalculateAttackDifficulty"),
       icon: "fas fa-calculator",
@@ -358,10 +356,10 @@ Hooks.on("getSceneControlButtons", function (hudButtons) {
         calculateAttackDifficulty();
       },
       button: true
-    });
+    };
   }
   if (tokenControls) {
-    tokenControls.tools.push({
+    tokenControls.tools["gmiRange"] = {
       name: "gmiRange",
       title: game.i18n.localize("CYPHERSYSTEM.GMIRange"),
       icon: "fas fa-exclamation-triangle",
@@ -369,10 +367,10 @@ Hooks.on("getSceneControlButtons", function (hudButtons) {
         gmiRangeForm();
       },
       button: true
-    });
+    };
   }
   if (tokenControls && game.user.isGM) {
-    tokenControls.tools.push({
+    tokenControls.tools["proposeGMI"] = {
       name: "proposeGMI",
       title: game.i18n.localize("CYPHERSYSTEM.ProposeIntrusion"),
       icon: "fas fa-bolt",
@@ -380,7 +378,7 @@ Hooks.on("getSceneControlButtons", function (hudButtons) {
         proposeIntrusion("", "");
       },
       button: true
-    });
+    };
   }
 });
 


### PR DESCRIPTION
Proposed changes

V13 changed the format of the `hudButtons.tokens` object structure so that the calls as they stood were throwing errors, causing the Cypher-specific HUD buttons not to appear.

This PR changes the syntax of those lines to mirror the new object structure. These changes have been tested in my local Foundry setup and I can confirm that the buttons are visible and working as expected with this fix in place.